### PR TITLE
Removed unused annotation from exporter services

### DIFF
--- a/ksonnet/monitoring/cadvisor.libsonnet
+++ b/ksonnet/monitoring/cadvisor.libsonnet
@@ -35,10 +35,6 @@
       "apiVersion": "v1",
       "kind": "Service",
       "metadata": {
-        "annotations": {
-          "prometheus.io/port": "8080",
-          "prometheus.io/scrape": "true"
-        },
         "labels": {
           "app": "dkube-pod-exporter"
         },

--- a/ksonnet/service/dkube-ext.libsonnet
+++ b/ksonnet/service/dkube-ext.libsonnet
@@ -7,10 +7,6 @@
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
-                "annotations": {
-                    "prometheus.io/port": "9401",
-                    "prometheus.io/scrape": "true"
-                },
                 "labels": {
                     "app": "dkube-gpu-exporter"
                 },


### PR DESCRIPTION
Removed unused annotation from exporter services to prevent discovery of these services from istio prometheus(It is installed with kubeflow 0.6.2 installation). However dkube prometheus discover these services by servicemonitor. 