### PR TITLE
Fix to allow /retry, /terminate directly to pl backend

### DIFF
--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -1298,7 +1298,7 @@ spec:
   http:
   - match:
     - method:
-        regex: POST|DELETE
+        exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/experiments
     route:
@@ -1312,9 +1312,9 @@ spec:
       retryOn: gateway-error,connect-failure,refused-stream
   - match:
     - method:
-        regex: POST|DELETE
+        exact: DELETE
       uri:
-        exact: /pipeline/apis/v1beta1/pipeline
+        prefix: /pipeline/apis/v1beta1/experiments
     route:
     - destination:
         host: dkube-controller-master
@@ -1326,7 +1326,42 @@ spec:
       retryOn: gateway-error,connect-failure,refused-stream
   - match:
     - method:
-        regex: POST|DELETE
+        exact: POST
+      uri:
+        exact: /pipeline/apis/v1beta1/pipelines/upload
+      uri:
+        exact: /pipeline/apis/v1beta1/pipelines
+      uri:
+        exact: /pipeline/apis/v1beta1/pipelines/upload_version
+      uri:
+        exact: /pipeline/apis/v1beta1/pipeline_versions
+    route:
+    - destination:
+        host: dkube-controller-master
+        port:
+          number: 5001
+    retries:
+      attempts: 3
+      perTryTimeout: 5s
+      retryOn: gateway-error,connect-failure,refused-stream
+  - match:
+    - method:
+        regex: DELETE
+      uri:
+        prefix: /pipeline/apis/v1beta1/pipelines
+    route:
+    - destination:
+        host: dkube-controller-master
+        port:
+          number: 5001
+    retries:
+      attempts: 3
+      perTryTimeout: 5s
+      retryOn: gateway-error,connect-failure,refused-stream
+
+  - match:
+    - method:
+        exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/runs
     route:
@@ -1338,6 +1373,22 @@ spec:
       attempts: 3
       perTryTimeout: 5s
       retryOn: gateway-error,connect-failure,refused-stream
+
+  - match:
+    - method:
+        exact: DELETE
+      uri:
+        prefix: /pipeline/apis/v1beta1/runs
+    route:
+    - destination:
+        host: dkube-controller-master
+        port:
+          number: 5001
+    retries:
+      attempts: 3
+      perTryTimeout: 5s
+      retryOn: gateway-error,connect-failure,refused-stream
+ 
   - match:
     - uri:
         prefix: /pipeline

--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -1300,7 +1300,7 @@ spec:
     - method:
         regex: POST|DELETE
       uri:
-        prefix: /pipeline/apis/v1beta1/experiments
+        exact: /pipeline/apis/v1beta1/experiments
     route:
     - destination:
         host: dkube-controller-master
@@ -1314,7 +1314,7 @@ spec:
     - method:
         regex: POST|DELETE
       uri:
-        prefix: /pipeline/apis/v1beta1/pipeline
+        exact: /pipeline/apis/v1beta1/pipeline
     route:
     - destination:
         host: dkube-controller-master
@@ -1328,7 +1328,7 @@ spec:
     - method:
         regex: POST|DELETE
       uri:
-        prefix: /pipeline/apis/v1beta1/runs
+        exact: /pipeline/apis/v1beta1/runs
     route:
     - destination:
         host: dkube-controller-master

--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -1329,10 +1329,16 @@ spec:
         exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/pipelines/upload
+    - method:
+        exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/pipelines
+    - method:
+        exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/pipelines/upload_version
+    - method:
+        exact: POST
       uri:
         exact: /pipeline/apis/v1beta1/pipeline_versions
     route:
@@ -1376,7 +1382,7 @@ spec:
 
   - match:
     - method:
-        exact: DELETE
+        prefix: DELETE
       uri:
         prefix: /pipeline/apis/v1beta1/runs
     route:


### PR DESCRIPTION
changed to match the url "exact" to make the other URLs like retry/terminate to go to kubeflow pl api directly as there is no user mapping needed for this apis

@dpaks 