### PR TITLE
state-exporter-fix

### DIFF
--- a/kustomize/monitoring/base/monitoring.yaml
+++ b/kustomize/monitoring/base/monitoring.yaml
@@ -429,7 +429,7 @@ spec:
         app: dkube-state-exporter
     spec:
       containers:
-      - image: gcr.io/google_containers/kube-state-metrics:v1.2.0
+      - image: quay.io/coreos/kube-state-metrics:v1.9.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The current kube-state-metrics uses v1beta1 api which is not supported in latest k8s versions. So updating the kube-state-metrics version. Tested this with k8s 1.16, 1.17 and k8s 1.18.
https://github.com/kubernetes/kube-state-metrics